### PR TITLE
Fix HasteImpl Regex

### DIFF
--- a/jest/hasteImpl.js
+++ b/jest/hasteImpl.js
@@ -27,7 +27,7 @@ const pluginRoots /*: Array<string> */ = haste.providesModuleNodeModules.map(
 );
 
 const pluginNameReducers /*: Array<[RegExp, string]> */ = haste.platforms.map(
-  name => [new RegExp(`^(.*)\.(${name})$`), '$1'],
+  name => [new RegExp(`^(.*)\\.(${name})$`), '$1'],
 );
 
 const ROOTS = [path.resolve(__dirname, '..') + path.sep, ...pluginRoots];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The jest HasteImpl's `pluginNameReducers` regex was not properly escaping a backslash, resulting in unintended behavior.

The intent of the code is to strip the `.${name}` from the end of a filepath, where `name` is a platform name. The correct regex for that would be `^(.*)\.(myPlat)$`, but because the regex is being constructed from a string, the `\.` is being interpreted as an escaped period, resulting in the regex  `^(.*).(myPlat)$`. To correct this, the backslash needs to be escaped so it makes it into the regex.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Fixed] - Fix HasteImpl platform name regex

## Test Plan

This is a stripped down version of `jest/hasteImpl.js` for testing. Can also be found at https://codepen.io/anon/pen/wZNovr?editors=0011
```
const haste = {
  platforms: ['ios', 'android', 'dummy']
};

const oldPluginNameReducers = haste.platforms.map(
  name => [new RegExp(`^(.*)\.(${name})$`), '$1'],
);

const newPluginNameReducers = haste.platforms.map(
  name => [new RegExp(`^(.*)\\.(${name})$`), '$1'],
);

function getHasteName(filePath, sourceCode) {
  console.log(`getHasteName('${filePath}')`);
  
  const oldHasteName = oldPluginNameReducers.reduce(
    (name, [pattern, replacement]) => name.replace(pattern, replacement),
    filePath,
  );
  console.log(`[OLD] ${oldHasteName}`);

  const newHasteName = newPluginNameReducers.reduce(
    (name, [pattern, replacement]) => name.replace(pattern, replacement),
    filePath,
  );
  console.log(`[NEW] ${newHasteName}`);
};

getHasteName('myComponent.ios');
getHasteName('myComponentios');

getHasteName('myComponent.dummy');
getHasteName('myComponent.ddummy');
```

Output:
```
getHasteName('myComponent.ios')
[OLD] myComponent
[NEW] myComponent
getHasteName('myComponentios')
[OLD] myComponen
[NEW] myComponentios
getHasteName('myComponent.dummy')
[OLD] myComponent
[NEW] myComponent
getHasteName('myComponent.ddummy')
[OLD] myComponent.
[NEW] myComponent.ddummy
```

